### PR TITLE
add default PageNumberPagination class for drf, size set to 100 records

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -291,6 +291,8 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.BasicAuthentication",
     ),
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 100
 }
 
 # django-cors-headers - https://github.com/adamchainz/django-cors-headers#setup


### PR DESCRIPTION
The API will now present paginated results.

The new default pagination class is the simple [PageNumberPagination](https://www.django-rest-framework.org/api-guide/pagination/#pagenumberpagination) class.

_Example:_
![image](https://user-images.githubusercontent.com/40369909/98568397-0da46280-227f-11eb-899a-ee8a79110831.png)
The `next` and `previous` keys will contain URLs for moving up/down pages respectively. The API also supports direct input of a page e.g. `?page=10` to navigate directly.

Note that this class can be easily overwritten for any endpoints.
