### PR TITLE
extend filter functionality across all ViewSets

### DIFF
--- a/bmh_lims/database/api/serializers.py
+++ b/bmh_lims/database/api/serializers.py
@@ -34,12 +34,52 @@ class WorkflowBatchSerializer(serializers.ModelSerializer):
         }
 
 
-class SampleSerializer(serializers.ModelSerializer):
+class LabSerializer(serializers.ModelSerializer):
     id = serializers.ReadOnlyField()
 
     class Meta:
-        model = models.Sample
+        model = models.Lab
         fields = '__all__'
+
+
+class ProjectSerializer(serializers.ModelSerializer):
+    id = serializers.ReadOnlyField()
+
+    class Meta:
+        model = models.Project
+        fields = '__all__'
+
+
+class SampleSerializer(serializers.ModelSerializer):
+    id = serializers.ReadOnlyField()
+    # submitting_lab = LabSerializer()  # TODO: Bug, cannot display for some reason
+    submitter_project = ProjectSerializer()
+
+    class Meta:
+        model = models.Sample
+        fields = [
+            'id',
+            'sample_id',
+            'sample_name',
+            'well',
+            # 'submitting_lab',
+            'sample_type',
+            'sample_volume_in_ul',
+            'requested_services',
+            'submitter_project',
+            'strain',
+            'isolate',
+            'genus',
+            'species',
+            'subspecies_subtype_lineage',
+            'approx_genome_size_in_bp',
+            'comments',
+            'culture_date',
+            'culture_conditions',
+            'dna_extraction_date',
+            'dna_extraction_method',
+            'qubit_concentration_in_ng_ul',
+        ]
 
 
 class WorkflowSampleSerializer(serializers.ModelSerializer):
@@ -81,19 +121,3 @@ class WorkflowSampleBatchSerializer(serializers.Serializer):
     def update(self, instance, validated_data):
         # TODO
         pass
-
-
-class LabSerializer(serializers.ModelSerializer):
-    id = serializers.ReadOnlyField()
-
-    class Meta:
-        model = models.Lab
-        fields = '__all__'
-
-
-class ProjectSerializer(serializers.ModelSerializer):
-    id = serializers.ReadOnlyField()
-
-    class Meta:
-        model = models.Project
-        fields = '__all__'

--- a/bmh_lims/database/api/views.py
+++ b/bmh_lims/database/api/views.py
@@ -26,7 +26,7 @@ class SampleViewSet(viewsets.ModelViewSet, UpdateModelMixin):
         'sample_id': ['iexact'],
         'sample_name': ['iexact', 'icontains'],
         'sample_type': ['iexact'],
-        'submitting_lab__lab_name': ['iexact', 'icontains'],
+        # 'submitting_lab__lab_name': ['iexact', 'icontains'],  # TODO: Bug, submitting_lab is broken at the moment
         'submitter_project__project_name': ['iexact', 'icontains'],
         'genus': ['iexact', 'icontains'],
         'species': ['iexact', 'icontains'],

--- a/bmh_lims/database/api/views.py
+++ b/bmh_lims/database/api/views.py
@@ -23,12 +23,17 @@ class SampleViewSet(viewsets.ModelViewSet, UpdateModelMixin):
     queryset = models.Sample.objects.all()
     filter_backends = [filters.SearchFilter, DjangoFilterBackend]
     filterset_fields = {
-        'sample_id': ['exact'],
+        'sample_id': ['iexact'],
         'sample_name': ['iexact'],
         'sample_type': ['iexact'],
         'genus': ['iexact'],
         'species': ['iexact'],
+        'strain': ['iexact'],
+        'isolate': ['iexact'],
+        'comments': ['icontains'],
         'created': ['date__range'],
+        'dna_extraction_date': ['range'],
+        'culture_date': ['range']
     }
 
     def create(self, request, *args, **kwargs):
@@ -110,6 +115,12 @@ class WorkflowSampleViewSet(viewsets.ModelViewSet, UpdateModelMixin):
     """
     serializer_class = serializers.WorkflowSampleSerializer
     queryset = models.WorkflowSample.objects.all()
+    filter_backends = [filters.SearchFilter, DjangoFilterBackend]
+    filterset_fields = {
+        'sample__sample_id': ['iexact'],
+        'sample__sample_name': ['iexact'],
+        'workflow_batch__status': ['iexact']
+    }
 
     def get_queryset(self):
         queryset = models.WorkflowSample.objects.all().order_by('-created')
@@ -121,6 +132,10 @@ class WorkflowBatchViewSet(viewsets.ModelViewSet, UpdateModelMixin):
     ViewSet for retrieving Sample objects from the database
     """
     serializer_class = serializers.WorkflowBatchSerializer
+    filter_backends = [filters.SearchFilter, DjangoFilterBackend]
+    filterset_fields = {
+        'status': ['iexact'],
+    }
 
     def get_queryset(self):
         queryset = models.WorkflowBatch.objects.all().order_by('-created')
@@ -133,6 +148,11 @@ class WorkflowDefinitionViewSet(viewsets.ModelViewSet, UpdateModelMixin):
     """
     serializer_class = serializers.WorkflowDefinitionSerializer
     queryset = models.WorkflowDefinition.objects.all()
+    filter_backends = [filters.SearchFilter, DjangoFilterBackend]
+    filterset_fields = {
+        'name': ['iexact'],
+        'description': ['icontains'],
+    }
 
     def get_queryset(self):
         queryset = models.WorkflowDefinition.objects.all().order_by('-created')
@@ -144,6 +164,11 @@ class ProjectViewSet(viewsets.ModelViewSet):
     ViewSet for retrieving Sample objects from the database
     """
     serializer_class = serializers.ProjectSerializer
+    filter_backends = [filters.SearchFilter, DjangoFilterBackend]
+    filterset_fields = {
+        'project_name': ['iexact'],
+        'project_description': ['icontains'],
+    }
 
     def get_queryset(self):
         queryset = models.Project.objects.all().order_by('-created')
@@ -155,6 +180,12 @@ class LabViewSet(viewsets.ModelViewSet):
     ViewSet for retrieving Sample objects from the database
     """
     serializer_class = serializers.LabSerializer
+    filter_backends = [filters.SearchFilter, DjangoFilterBackend]
+    filterset_fields = {
+        'lab_name': ['iexact'],
+        'lab_contact': ['iexact'],
+        'lab_notes': ['icontains']
+    }
 
     def get_queryset(self):
         queryset = models.Lab.objects.all().order_by('-created')

--- a/bmh_lims/database/api/views.py
+++ b/bmh_lims/database/api/views.py
@@ -24,10 +24,12 @@ class SampleViewSet(viewsets.ModelViewSet, UpdateModelMixin):
     filter_backends = [filters.SearchFilter, DjangoFilterBackend]
     filterset_fields = {
         'sample_id': ['iexact'],
-        'sample_name': ['iexact'],
+        'sample_name': ['iexact', 'icontains'],
         'sample_type': ['iexact'],
-        'genus': ['iexact'],
-        'species': ['iexact'],
+        'submitting_lab__lab_name': ['iexact', 'icontains'],
+        'submitter_project__project_name': ['iexact', 'icontains'],
+        'genus': ['iexact', 'icontains'],
+        'species': ['iexact', 'icontains'],
         'strain': ['iexact'],
         'isolate': ['iexact'],
         'comments': ['icontains'],


### PR DESCRIPTION
For more information on how these filters can be used, navigate to the endpoint you're interested in at /api/ and click the 'Filters' button. From here, you can use the form which will generate an URL you can work with when building future requests.

![image](https://user-images.githubusercontent.com/40369909/99845537-cd789600-2b42-11eb-9054-456b84f12c5e.png)
_See the 'Filters' button_

Note that not all parameters are required when building a URL. The parameters are quite verbose right now, though they explain exactly how the filter is behaving, e.g. `iexact` indicates exact case-insensitive matches, whereas `icontains` indicates case-insensitive partial string searching.

Additional filtering on more model fields can be added in the future as necessary.